### PR TITLE
Remove Legend from Recharts imports

### DIFF
--- a/fiisimulator.js
+++ b/fiisimulator.js
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   BarChart,
   Bar


### PR DESCRIPTION
## Summary
- remove unused `Legend` import from `fiisimulator.js`

## Testing
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861d56b83d4833388e596de1d4ec891